### PR TITLE
Support storing configuration in project's configuration.

### DIFF
--- a/src/main/java/org/luksza/gerrit/rest/Urls.java
+++ b/src/main/java/org/luksza/gerrit/rest/Urls.java
@@ -14,6 +14,7 @@
 
 package org.luksza.gerrit.rest;
 
+import com.google.gerrit.reviewdb.client.Project;
 import com.google.inject.Inject;
 
 import org.luksza.gerrit.config.ConfigurationProvider;
@@ -26,11 +27,11 @@ public class Urls {
     this.config = config;
   }
 
-  String getSearchUrl() {
-    return config.getJenkinsUrl() + "gerrit_manual_trigger/gerritSearch";
+  String getSearchUrl(Project.NameKey project) {
+    return config.getJenkinsUrl(project) + "gerrit_manual_trigger/gerritSearch";
   }
 
-  String getBuildUrl() {
-    return config.getJenkinsUrl() + "gerrit_manual_trigger/build";
+  String getBuildUrl(Project.NameKey project) {
+    return config.getJenkinsUrl(project) + "gerrit_manual_trigger/build";
   }
 }


### PR DESCRIPTION
With this patch, the jenkins URL will be read from the project's config, otherwise from the projects it inherits from, and as a last resort (for compatibility) from gerrit.config.

This allows associating different Jenkins servers for each project.
